### PR TITLE
Add profile editing and public instructor listing with Tailwind styles

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,12 @@
 <script>
+  import '../app.css';
   export let data;
 </script>
-
-<slot />
+<nav class="bg-purple-600 text-white p-4 flex gap-4">
+  <a href="/" class="font-bold">Home</a>
+  <a href="/profile" class="bg-white text-purple-600 px-3 py-1 rounded font-bold">Profile</a>
+  <a href="/instructors" class="bg-white text-purple-600 px-3 py-1 rounded font-bold">Browse Instructors</a>
+</nav>
+<main class="p-4">
+  <slot />
+</main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,7 @@
-<h1>Welcome to Smithers Skill Swap</h1>
-<p>Your community event app.</p>
+<h1 class="text-4xl font-bold text-purple-700">Welcome to Smithers Skill Swap</h1>
+<p class="mt-4">Your community event app.</p>
+<a
+  href="/instructors"
+  class="inline-block mt-6 bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded"
+  >Browse Instructors</a
+>

--- a/src/routes/instructors/+page.svelte
+++ b/src/routes/instructors/+page.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { supabase } from '$lib/supabase';
+  let profiles = [];
+  supabase
+    .from('profiles')
+    .select('email, name, bio')
+    .eq('is_public', true)
+    .then(({ data }) => (profiles = data || []));
+</script>
+
+<h2 class="text-2xl font-bold text-purple-700">Browse Instructors</h2>
+<div class="grid gap-4 mt-4 md:grid-cols-2">
+  {#each profiles as profile}
+    <div class="border p-4 rounded shadow bg-blue-50">
+      <h3 class="text-xl font-bold">{profile.name}</h3>
+      <p class="mb-2">{profile.bio}</p>
+      <a
+        href="mailto:{profile.email}"
+        class="inline-block bg-blue-600 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded"
+        >Contact</a
+      >
+    </div>
+  {/each}
+</div>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,0 +1,66 @@
+<script>
+  import { supabase } from '$lib/supabase';
+  let email = '';
+  let name = '';
+  let bio = '';
+  let isPublic = false;
+
+  async function loadProfile() {
+    if (!email) return;
+    const { data } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('email', email)
+      .single();
+    if (data) {
+      name = data.name || '';
+      bio = data.bio || '';
+      isPublic = data.is_public || false;
+    }
+  }
+
+  async function saveProfile() {
+    const { error } = await supabase.from('profiles').upsert({
+      email,
+      name,
+      bio,
+      is_public: isPublic
+    });
+    if (!error) {
+      alert('Profile saved');
+    }
+  }
+</script>
+
+<h2 class="text-2xl font-bold text-purple-700">Your Profile</h2>
+<form on:submit|preventDefault={saveProfile} class="space-y-4 mt-4 max-w-md">
+  <input
+    type="email"
+    placeholder="Email"
+    bind:value={email}
+    class="border p-2 w-full"
+    required
+    on:blur={loadProfile}
+  />
+  <input
+    type="text"
+    placeholder="Name"
+    bind:value={name}
+    class="border p-2 w-full"
+  />
+  <textarea
+    placeholder="Bio"
+    bind:value={bio}
+    class="border p-2 w-full"
+  ></textarea>
+  <label class="flex items-center">
+    <input type="checkbox" bind:checked={isPublic} class="mr-2" />
+    Make profile public
+  </label>
+  <button
+    type="submit"
+    class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded"
+  >
+    Save
+  </button>
+</form>


### PR DESCRIPTION
## Summary
- enable Tailwind styles and add navigation with bold colored buttons
- allow users to create or edit their profile and mark it public
- list public profiles on a Browse Instructors page with stylized cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Invalid command: build)*

------
https://chatgpt.com/codex/tasks/task_e_68904270d6fc83299170d0cef935b022